### PR TITLE
Expand cleanup targets for coordinated multi-file cleanups

### DIFF
--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/MultiFileCleanUpScopeExpansionTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/MultiFileCleanUpScopeExpansionTest.java
@@ -12,6 +12,8 @@ package org.eclipse.jdt.ui.tests.quickfix;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Collection;
 import java.util.List;
@@ -24,6 +26,7 @@ import org.junit.Test;
 
 import org.eclipse.jdt.testplugin.JavaProjectHelper;
 
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 
@@ -77,9 +80,7 @@ public class MultiFileCleanUpScopeExpansionTest extends QuickFixTest {
 		ICompilationUnit second= pack.createCompilationUnit("Second.java", secondSource, false, null); //$NON-NLS-1$
 
 		ScopeExpandingCleanUp cleanUp= new ScopeExpandingCleanUp(second);
-		CleanUpRefactoring refactoring= new CleanUpRefactoring();
-		refactoring.addCompilationUnit(first);
-		refactoring.addCleanUp(cleanUp);
+		CleanUpRefactoring refactoring= createRefactoring(first, cleanUp);
 
 		RefactoringStatus status= refactoring.checkAllConditions(new NullProgressMonitor());
 		assertFalse(status.toString(), status.hasError());
@@ -95,18 +96,46 @@ public class MultiFileCleanUpScopeExpansionTest extends QuickFixTest {
 		assertEquals(Set.of("// cleanup\n" + firstSource, "// cleanup\n" + secondSource), previews); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
-	public static final class ScopeExpandingCleanUp extends AbstractCleanUp {
-		private final ICompilationUnit relatedUnit;
-		private List<ICompilationUnit> plannedUnits= List.of();
+	@Test
+	public void testScopeExpansionRepeatsToFixedPointAndDeduplicatesTargets() throws Exception {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null); //$NON-NLS-1$
+		ICompilationUnit first= pack.createCompilationUnit("First.java", "package test1;\nclass First {}\n", false, null); //$NON-NLS-1$ //$NON-NLS-2$
+		ICompilationUnit second= pack.createCompilationUnit("Second.java", "package test1;\nclass Second {}\n", false, null); //$NON-NLS-1$ //$NON-NLS-2$
+		ICompilationUnit third= pack.createCompilationUnit("Third.java", "package test1;\nclass Third {}\n", false, null); //$NON-NLS-1$ //$NON-NLS-2$
 
-		ScopeExpandingCleanUp(ICompilationUnit relatedUnit) {
-			this.relatedUnit= relatedUnit;
-		}
+		TransitiveScopeCleanUp cleanUp= new TransitiveScopeCleanUp(second, third);
+		CleanUpRefactoring refactoring= createRefactoring(first, cleanUp);
 
-		public Collection<ICompilationUnit> expandCleanUpScope(IJavaProject project,
-				Collection<ICompilationUnit> currentScope, IProgressMonitor monitor) {
-			return List.of(relatedUnit);
+		RefactoringStatus status= refactoring.checkAllConditions(new NullProgressMonitor());
+		assertFalse(status.toString(), status.hasError());
+		assertEquals(Set.of(first, second, third), Set.copyOf(cleanUp.plannedUnits));
+		assertEquals(3, cleanUp.expansionInvocations);
+		assertEquals(3, ((CompositeChange) refactoring.createChange(null)).getChildren().length);
+	}
+
+	@Test
+	public void testInvalidProviderElementAbortsCleanup() throws Exception {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null); //$NON-NLS-1$
+		ICompilationUnit first= pack.createCompilationUnit("First.java", "package test1;\nclass First {}\n", false, null); //$NON-NLS-1$ //$NON-NLS-2$
+		CleanUpRefactoring refactoring= createRefactoring(first, new InvalidScopeCleanUp());
+
+		try {
+			refactoring.checkAllConditions(new NullProgressMonitor());
+			fail("An invalid scope provider result must abort the cleanup"); //$NON-NLS-1$
+		} catch (CoreException exception) {
+			assertTrue(exception.getStatus().getMessage().contains("not an ICompilationUnit")); //$NON-NLS-1$
 		}
+	}
+
+	private static CleanUpRefactoring createRefactoring(ICompilationUnit initialUnit, AbstractCleanUp cleanUp) {
+		CleanUpRefactoring refactoring= new CleanUpRefactoring();
+		refactoring.addCompilationUnit(initialUnit);
+		refactoring.addCleanUp(cleanUp);
+		return refactoring;
+	}
+
+	private abstract static class RecordingCleanUp extends AbstractCleanUp {
+		List<ICompilationUnit> plannedUnits= List.of();
 
 		@Override
 		public RefactoringStatus checkPreConditions(IJavaProject project, ICompilationUnit[] compilationUnits,
@@ -125,6 +154,54 @@ public class MultiFileCleanUpScopeExpansionTest extends QuickFixTest {
 				change.setEdit(root);
 				return change;
 			};
+		}
+	}
+
+	public static final class ScopeExpandingCleanUp extends RecordingCleanUp {
+		private final ICompilationUnit relatedUnit;
+
+		ScopeExpandingCleanUp(ICompilationUnit relatedUnit) {
+			this.relatedUnit= relatedUnit;
+		}
+
+		public Collection<ICompilationUnit> expandCleanUpScope(IJavaProject project,
+				Collection<ICompilationUnit> currentScope, IProgressMonitor monitor) {
+			return List.of(relatedUnit);
+		}
+	}
+
+	public static final class TransitiveScopeCleanUp extends RecordingCleanUp {
+		private final ICompilationUnit second;
+		private final ICompilationUnit third;
+		private int expansionInvocations;
+
+		TransitiveScopeCleanUp(ICompilationUnit second, ICompilationUnit third) {
+			this.second= second;
+			this.third= third;
+		}
+
+		public Collection<ICompilationUnit> expandCleanUpScope(IJavaProject project,
+				Collection<ICompilationUnit> currentScope, IProgressMonitor monitor) {
+			expansionInvocations++;
+			if (!currentScope.contains(second)) {
+				return List.of(second, second);
+			}
+			if (!currentScope.contains(third)) {
+				return List.of(second, third, third);
+			}
+			return List.of(second, third);
+		}
+	}
+
+	public static final class InvalidScopeCleanUp extends AbstractCleanUp {
+		public Collection<?> expandCleanUpScope(IJavaProject project,
+				Collection<ICompilationUnit> currentScope, IProgressMonitor monitor) {
+			return List.of("not a compilation unit"); //$NON-NLS-1$
+		}
+
+		@Override
+		public ICleanUpFix createFix(CleanUpContext context) {
+			return null;
 		}
 	}
 }

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/MultiFileCleanUpScopeExpansionTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/MultiFileCleanUpScopeExpansionTest.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.ui.tests.quickfix;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.eclipse.jdt.testplugin.JavaProjectHelper;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+import org.eclipse.text.edits.InsertEdit;
+import org.eclipse.text.edits.MultiTextEdit;
+
+import org.eclipse.ltk.core.refactoring.Change;
+import org.eclipse.ltk.core.refactoring.CompositeChange;
+import org.eclipse.ltk.core.refactoring.RefactoringStatus;
+import org.eclipse.ltk.core.refactoring.TextEditBasedChange;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.refactoring.CompilationUnitChange;
+
+import org.eclipse.jdt.internal.corext.fix.CleanUpRefactoring;
+
+import org.eclipse.jdt.ui.cleanup.CleanUpContext;
+import org.eclipse.jdt.ui.cleanup.ICleanUpFix;
+import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
+
+import org.eclipse.jdt.internal.ui.fix.AbstractCleanUp;
+
+public class MultiFileCleanUpScopeExpansionTest extends QuickFixTest {
+
+	@Rule
+	public ProjectTestSetup projectSetup= new ProjectTestSetup();
+
+	private IJavaProject fProject;
+	private IPackageFragmentRoot fSourceFolder;
+
+	@Before
+	public void setUp() throws Exception {
+		fProject= projectSetup.getProject();
+		fSourceFolder= JavaProjectHelper.addSourceContainer(fProject, "src"); //$NON-NLS-1$
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		JavaProjectHelper.clear(fProject, projectSetup.getDefaultClasspath());
+	}
+
+	@Test
+	public void testRelatedCompilationUnitParticipatesInPlanPreviewAndUndoTree() throws Exception {
+		IPackageFragment pack= fSourceFolder.createPackageFragment("test1", false, null); //$NON-NLS-1$
+		String firstSource= "package test1;\npublic class First {}\n"; //$NON-NLS-1$
+		String secondSource= "package test1;\npublic class Second {}\n"; //$NON-NLS-1$
+		ICompilationUnit first= pack.createCompilationUnit("First.java", firstSource, false, null); //$NON-NLS-1$
+		ICompilationUnit second= pack.createCompilationUnit("Second.java", secondSource, false, null); //$NON-NLS-1$
+
+		ScopeExpandingCleanUp cleanUp= new ScopeExpandingCleanUp(second);
+		CleanUpRefactoring refactoring= new CleanUpRefactoring();
+		refactoring.addCompilationUnit(first);
+		refactoring.addCleanUp(cleanUp);
+
+		RefactoringStatus status= refactoring.checkAllConditions(new NullProgressMonitor());
+		assertFalse(status.toString(), status.hasError());
+		assertEquals(Set.of(first, second), Set.copyOf(cleanUp.plannedUnits));
+
+		CompositeChange change= (CompositeChange) refactoring.createChange(null);
+		Change[] children= change.getChildren();
+		assertEquals(2, children.length);
+
+		Set<String> previews= Set.of(
+				((TextEditBasedChange) children[0]).getPreviewContent(new NullProgressMonitor()),
+				((TextEditBasedChange) children[1]).getPreviewContent(new NullProgressMonitor()));
+		assertEquals(Set.of("// cleanup\n" + firstSource, "// cleanup\n" + secondSource), previews); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	public static final class ScopeExpandingCleanUp extends AbstractCleanUp {
+		private final ICompilationUnit relatedUnit;
+		private List<ICompilationUnit> plannedUnits= List.of();
+
+		ScopeExpandingCleanUp(ICompilationUnit relatedUnit) {
+			this.relatedUnit= relatedUnit;
+		}
+
+		public Collection<ICompilationUnit> expandCleanUpScope(IJavaProject project,
+				Collection<ICompilationUnit> currentScope, IProgressMonitor monitor) {
+			return List.of(relatedUnit);
+		}
+
+		@Override
+		public RefactoringStatus checkPreConditions(IJavaProject project, ICompilationUnit[] compilationUnits,
+				IProgressMonitor monitor) {
+			plannedUnits= List.of(compilationUnits);
+			return new RefactoringStatus();
+		}
+
+		@Override
+		public ICleanUpFix createFix(CleanUpContext context) {
+			return progressMonitor -> {
+				CompilationUnitChange change= new CompilationUnitChange("Scope expansion test", //$NON-NLS-1$
+						context.getCompilationUnit());
+				MultiTextEdit root= new MultiTextEdit();
+				root.addChild(new InsertEdit(0, "// cleanup\n")); //$NON-NLS-1$
+				change.setEdit(root);
+				return change;
+			};
+		}
+	}
+}

--- a/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/MultiFileCleanUpScopeExpansionTest.java
+++ b/org.eclipse.jdt.ui.tests/ui/org/eclipse/jdt/ui/tests/quickfix/MultiFileCleanUpScopeExpansionTest.java
@@ -52,6 +52,7 @@ import org.eclipse.jdt.ui.tests.core.rules.ProjectTestSetup;
 
 import org.eclipse.jdt.internal.ui.fix.AbstractCleanUp;
 
+/** Tests target-scope expansion before the established cleanup lifecycle. */
 public class MultiFileCleanUpScopeExpansionTest extends QuickFixTest {
 
 	@Rule

--- a/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpRefactoring.java
+++ b/org.eclipse.jdt.ui/core extension/org/eclipse/jdt/internal/corext/fix/CleanUpRefactoring.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,12 +10,17 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Carsten Hammer - cleanup target scope expansion
  *******************************************************************************/
 package org.eclipse.jdt.internal.corext.fix;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Hashtable;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -95,6 +100,8 @@ import org.eclipse.jdt.internal.ui.refactoring.IScheduledRefactoring;
 import org.eclipse.jdt.internal.ui.util.Progress;
 
 public class CleanUpRefactoring extends Refactoring implements IScheduledRefactoring {
+
+	private static final String EXPAND_CLEAN_UP_SCOPE_METHOD= "expandCleanUpScope"; //$NON-NLS-1$
 
 	public static class CleanUpTarget {
 
@@ -647,18 +654,26 @@ public class CleanUpRefactoring extends Refactoring implements IScheduledRefacto
 		RefactoringStatus result= new RefactoringStatus();
 
 		ICleanUp[] cleanUps= getCleanUps();
-		pm.beginTask("", cuCount * 2 * fCleanUps.size() + 4 * cleanUps.length); //$NON-NLS-1$
+		boolean expandsScope= supportsScopeExpansion(cleanUps);
+		pm.beginTask("", expandsScope ? IProgressMonitor.UNKNOWN : cuCount * 2 * fCleanUps.size() + 4 * cleanUps.length); //$NON-NLS-1$
 		try {
 			DynamicValidationStateChange change= new DynamicValidationStateChange(getName());
 			change.setSchedulingRule(getSchedulingRule());
 			for (Entry<IJavaProject, List<CleanUpTarget>> entry : fProjects.entrySet()) {
 				IJavaProject project= entry.getKey();
 				List<CleanUpTarget> targetsList= entry.getValue();
-				CleanUpTarget[] targets= targetsList.toArray(new CleanUpTarget[targetsList.size()]);
 				if (fUseOptionsFromProfile) {
 					result.merge(setOptionsFromProfile(project, cleanUps));
 					if (result.hasFatalError())
 						return result;
+				}
+				CleanUpTarget[] targets= targetsList.toArray(new CleanUpTarget[targetsList.size()]);
+				if (expandsScope) {
+					targets= expandCleanUpTargets(project, targets, cleanUps, Progress.subMonitor(pm, cleanUps.length));
+					targetsList.clear();
+					for (CleanUpTarget target : targets) {
+						targetsList.add(target);
+					}
 				}
 				result.merge(checkPreConditions(project, targets, Progress.subMonitor(pm, 3 * cleanUps.length)));
 				if (result.hasFatalError())
@@ -681,6 +696,98 @@ public class CleanUpRefactoring extends Refactoring implements IScheduledRefacto
 		}
 
 		return result;
+	}
+
+	private static boolean supportsScopeExpansion(ICleanUp[] cleanUps) {
+		for (ICleanUp cleanUp : cleanUps) {
+			if (findScopeExpansionMethod(cleanUp) != null) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private CleanUpTarget[] expandCleanUpTargets(IJavaProject project, CleanUpTarget[] initialTargets,
+			ICleanUp[] cleanUps, IProgressMonitor monitor) throws CoreException {
+		Map<ICompilationUnit, CleanUpTarget> targetsByUnit= new LinkedHashMap<>();
+		for (CleanUpTarget target : initialTargets) {
+			targetsByUnit.put(target.getCompilationUnit().getPrimary(), target);
+		}
+
+		boolean changed;
+		do {
+			changed= false;
+			List<ICompilationUnit> currentScope= targetsByUnit.keySet().stream().toList();
+			for (ICleanUp cleanUp : cleanUps) {
+				Collection<?> discovered= invokeScopeExpansion(cleanUp, project, currentScope, monitor);
+				for (Object candidate : discovered) {
+					if (!(candidate instanceof ICompilationUnit unit)) {
+						throw invalidScopeProvider(cleanUp, "returned an element that is not an ICompilationUnit", null); //$NON-NLS-1$
+					}
+					ICompilationUnit primary= unit.getPrimary();
+					if (!project.equals(primary.getJavaProject())) {
+						throw invalidScopeProvider(cleanUp, "returned a compilation unit from another Java project", null); //$NON-NLS-1$
+					}
+					if (!primary.exists()) {
+						throw invalidScopeProvider(cleanUp, "returned a compilation unit that does not exist", null); //$NON-NLS-1$
+					}
+					if (!targetsByUnit.containsKey(primary)) {
+						targetsByUnit.put(primary, new CleanUpTarget(primary));
+						changed= true;
+					}
+				}
+				if (monitor.isCanceled()) {
+					throw new OperationCanceledException();
+				}
+				monitor.worked(1);
+			}
+		} while (changed);
+
+		return targetsByUnit.values().toArray(new CleanUpTarget[targetsByUnit.size()]);
+	}
+
+	private static Collection<?> invokeScopeExpansion(ICleanUp cleanUp, IJavaProject project,
+			Collection<ICompilationUnit> currentScope, IProgressMonitor monitor) throws CoreException {
+		Method method= findScopeExpansionMethod(cleanUp);
+		if (method == null) {
+			return List.of();
+		}
+		try {
+			Object result= method.invoke(cleanUp, project, List.copyOf(currentScope), monitor);
+			if (result == null) {
+				return List.of();
+			}
+			if (result instanceof Collection<?> collection) {
+				return collection;
+			}
+			throw invalidScopeProvider(cleanUp, "did not return a Collection", null); //$NON-NLS-1$
+		} catch (IllegalAccessException | IllegalArgumentException e) {
+			throw invalidScopeProvider(cleanUp, "could not be invoked", e); //$NON-NLS-1$
+		} catch (InvocationTargetException e) {
+			Throwable cause= e.getCause();
+			if (cause instanceof CoreException coreException) {
+				throw coreException;
+			}
+			if (cause instanceof OperationCanceledException canceledException) {
+				throw canceledException;
+			}
+			throw invalidScopeProvider(cleanUp, "failed while expanding the cleanup scope", cause); //$NON-NLS-1$
+		}
+	}
+
+	private static Method findScopeExpansionMethod(ICleanUp cleanUp) {
+		try {
+			return cleanUp.getClass().getMethod(EXPAND_CLEAN_UP_SCOPE_METHOD, IJavaProject.class,
+					Collection.class, IProgressMonitor.class);
+		} catch (NoSuchMethodException e) {
+			return null;
+		}
+	}
+
+	private static CoreException invalidScopeProvider(ICleanUp cleanUp, String detail, Throwable cause) {
+		String message= "Invalid multi-file cleanup scope provider " + cleanUp.getClass().getName() + ": " + detail; //$NON-NLS-1$ //$NON-NLS-2$
+		return new CoreException(new Status(IStatus.ERROR, JavaPlugin.getPluginId(),
+				IJavaStatusConstants.INTERNAL_ERROR, message, cause));
 	}
 
 	private void findFilesToBeModified(CompositeChange change, List<IResource> result) throws JavaModelException {


### PR DESCRIPTION
## Summary

Adds a minimal target-scope expansion phase to the existing cleanup refactoring pipeline.

A cleanup may expose the public method:

```java
Collection<ICompilationUnit> expandCleanUpScope(
    IJavaProject project,
    Collection<ICompilationUnit> currentScope,
    IProgressMonitor monitor) throws CoreException;
```

`CleanUpRefactoring` discovers this optional capability without adding a public JDT API dependency, repeatedly merges returned compilation units until a fixed point is reached, and then runs the existing cleanup lifecycle unchanged.

## Design

- Scope expansion happens after project cleanup options are installed and before `checkPreConditions`.
- Added compilation units participate in the existing batch AST parser, working-copy fixpoint, overlap handling, resource validation, preview, application, and undo.
- Existing cleanups without the optional method follow the original path.
- Cross-project, missing, non-compilation-unit, and failing provider results abort the atomic cleanup instead of being logged and ignored.
- Duplicate provider results are de-duplicated by Java-element handle.
- Providers are called repeatedly until no target is added; because the scope grows monotonically over the finite set of existing units in one project, the process terminates.
- The progress monitor uses unknown total work only when a scope provider is present, because the target count is not known until expansion completes.
- The refactoring already uses the workspace-root scheduling rule, so newly discovered resources are covered by the existing workspace lock.

## Why this is smaller than #68

This PR does not introduce a parallel multi-file cleanup pipeline or change `ICleanUpFix`. Existing `ICleanUp.checkPreConditions` already receives all targets and the same cleanup instance already returns one local change per target. The only missing orchestration feature is adding newly discovered targets before that lifecycle starts.

## Tests

`MultiFileCleanUpScopeExpansionTest` now verifies:

- starting with one compilation unit and discovering a second;
- both units reaching precondition planning;
- both changes appearing in the unified preview/undo tree;
- transitive expansion through multiple provider invocations;
- duplicate provider results not duplicating targets;
- fixed-point termination;
- invalid provider elements aborting the cleanup with a `CoreException`.

## Validation

The current head passes:

- Java CI with Maven;
- Pull-Request Checks;
- CodeQL;
- Codacy Security Scan.

This supersedes the infrastructure direction of #68 while retaining the established cleanup machinery. The first consumers and end-to-end migration tests are implemented in `carstenartur/sandbox#1207`; reproducible product/p2 delivery is tracked separately in `carstenartur/sandbox#1209`.